### PR TITLE
Java 21 settes som default for samtlige maven prosjekter

### DIFF
--- a/.github/actions/setup-java-and-maven/action.yml
+++ b/.github/actions/setup-java-and-maven/action.yml
@@ -7,7 +7,7 @@ inputs:
   java-version:
     description: 'Java SDK version to use'
     required: false
-    default: '17'
+    default: '21'
   maven-version:
     description: 'Maven version to use'
     required: false

--- a/.github/workflows/build-app-no-db.yml
+++ b/.github/workflows/build-app-no-db.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
         description: Java SDK versjon som skal brukes.
-        default: '17'
+        default: '21'
       sonar-scan:
         required: false
         type: boolean

--- a/.github/workflows/build-app-postgres.yml
+++ b/.github/workflows/build-app-postgres.yml
@@ -20,7 +20,7 @@ on:
         required: false
         type: string
         description: Java SDK versjon som skal brukes.
-        default: '17'
+        default: '21'
       sonar-scan:
         required: false
         type: boolean

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
         description: Java SDK versjon som skal brukes.
-        default: '17'
+        default: '21'
       sonar-scan:
         required: false
         type: boolean

--- a/.github/workflows/build-feature-postgres.yml
+++ b/.github/workflows/build-feature-postgres.yml
@@ -20,7 +20,7 @@ on:
         required: false
         type: string
         description: Java SDK versjon som skal brukes.
-        default: '17'
+        default: '21'
       sonar-scan:
         required: false
         type: boolean

--- a/.github/workflows/build-feature.yml
+++ b/.github/workflows/build-feature.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
         description: Java SDK versjon som skal brukes.
-        default: '17'
+        default: 21'
       sonar-scan:
         required: false
         type: boolean

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,7 @@ on:
         required: false
         type: string
         description: Java SDK versjon som skal brukes.
-        default: '17'
+        default: '21'
       language:
         required: false
         type: string

--- a/.github/workflows/mvn-dependency-submission.yml
+++ b/.github/workflows/mvn-dependency-submission.yml
@@ -6,7 +6,7 @@ on:
         required: false
         type: string
         description: Java SDK versjon som skal brukes.
-        default: '17'
+        default: '21'
 jobs:
   scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-feature.yml
+++ b/.github/workflows/release-feature.yml
@@ -10,7 +10,7 @@ on:
         required: false
         type: string
         description: 'Java SDK versjon som skal brukes.'
-        default: '17'
+        default: '21'
       mvn-projects:
         required: false
         type: string


### PR DESCRIPTION
K9 har avhengigheter inn her i følgende repo. Her er det bare codeql.yml action. k9-ws-proxy har flere avhengigheter, men tenker jeg ikker er problematisk. PR er opprettet og de får merge når de får tid:
https://github.com/navikt/k9-punsj/pull/1036
https://github.com/navikt/ft-kalkulus/pull/4347
https://github.com/navikt/k9-ws-proxy/pull/22
https://github.com/navikt/k9-oppdrag/pull/2127

Tenker vi bare får ut denne med en gang slik at vi slipper å gå i hvert repo å spesifisere java-versjon. Default blir nå 21, og avvikene må spesifisere.
