### PR TITLE
Revert "Bump advanced-security/maven-dependency-submission-action from 4.0.0 to 4.0.1 in /.github/workflows"

### DIFF
--- a/.github/workflows/mvn-dependency-submission.yml
+++ b/.github/workflows/mvn-dependency-submission.yml
@@ -32,7 +32,7 @@ jobs:
           echo "Building artifacts ${{ steps.generate-build-version.outputs.build-version }}"
           mvn versions:set -DnewVersion="${{ steps.generate-build-version.outputs.build-version }}" -s settings.xml -q -e -B
       - name: Submit Dependency Snapshot to Github Security
-        uses: advanced-security/maven-dependency-submission-action@73da25169f2ac4d336320399ba58070deebc1208
+        uses: advanced-security/maven-dependency-submission-action@ed72a3242c5331913886b41ca9ea66c9195ebdaa
         with:
           settings-file: settings.xml
           maven-args: -DskipTests


### PR DESCRIPTION
Reverts navikt/fp-gha-workflows#96