### PR TITLE
Revert "Legg til yarn config etter man har cd til server(#167)"

### DIFF
--- a/.github/workflows/build-app-frontend-yarn.yml
+++ b/.github/workflows/build-app-frontend-yarn.yml
@@ -6,12 +6,12 @@ on:
         required: false
         type: string
         description: Miljø versjon som skal brukes til bygg.
-        default: "ubuntu-latest"
+        default: 'ubuntu-latest'
       node-version:
         required: false
         type: string
         description: Node version som brukes.
-        default: "18.8.0"
+        default: '18.8.0'
       build-image:
         required: false
         type: boolean
@@ -42,6 +42,13 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # ratchet:actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Sette yarn-config
+        run: |
+          yarn config set npmScopes.navikt.npmRegistryServer "https://npm.pkg.github.com"
+          yarn config set npmScopes.navikt.npmAlwaysAuth true
+          yarn config set npmScopes.navikt.npmAuthToken $NPM_AUTH_TOKEN
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
       - name: Set up NODE med yarn
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # ratchet:actions/setup-node@v3
         with:
@@ -65,14 +72,7 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       - name: Bygg server
-        run: |
-          cd ./server
-          yarn config set npmScopes.navikt.npmRegistryServer "https://npm.pkg.github.com"
-          yarn config set npmScopes.navikt.npmAlwaysAuth true
-          yarn config set npmScopes.navikt.npmAuthToken ${NODE_AUTH_TOKEN}
-          yarn install --immutable
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+        run: cd ./server && yarn install --immutable
       - name: Generate build version
         id: generate-build-version
         run: |


### PR DESCRIPTION
This reverts commit 9eafa3abfdcd6fa19f40c9d5f9ff96137f1e2e17.

Denne behøves ikke lenger når vi kun har en .yarnrc.yml fil globalt i fp-frontend og ikke en på rot  og i `server/`