### PR TITLE
Feat/Add workflows for cleanup and deployment of Storybook branches

### DIFF
--- a/.github/workflows/cleanup-storybook-branch.yml
+++ b/.github/workflows/cleanup-storybook-branch.yml
@@ -5,7 +5,7 @@ on:
       branch-name:
         required: true
         type: string
-        description: Navn på branchen som skal slettes
+        description: Navn på branchen som skal slettes (IKKE main/master)
   workflow_call:
     secrets:
       GITHUB_TOKEN:
@@ -26,13 +26,26 @@ jobs:
       deployments: write
     runs-on: "ubuntu-latest"
     steps:
-      # Trinn 1: Sjekk ut repository (gh-pages branch)
+      # Trinn 1: Sjekk at vi ikke sletter main/master
+      - name: Sjekk at branch ikke er main/master
+        run: |
+          BRANCH_NAME="${{ inputs.branch-name }}"
+
+          if [ "$BRANCH_NAME" = "main" ] || [ "$BRANCH_NAME" = "master" ]; then
+            echo "❌ Kan ikke slette deployment for main/master branches!"
+            echo "Disse er rot-deployments som skal forbli."
+            exit 1
+          fi
+
+          echo "✅ Branch '$BRANCH_NAME' er OK for cleanup"
+
+      # Trinn 2: Sjekk ut repository (gh-pages branch)
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           ref: gh-pages
           token: ${{ secrets.GITHUB_TOKEN || github.token }}
 
-      # Trinn 2: Konverter branch navn til URL-vennlig format
+      # Trinn 3: Konverter branch navn til URL-vennlig format
       - name: Sett branch navn
         id: branch-info
         run: |

--- a/.github/workflows/cleanup-storybook-branch.yml
+++ b/.github/workflows/cleanup-storybook-branch.yml
@@ -1,0 +1,97 @@
+name: Cleanup storybook branch
+on:
+  workflow_dispatch:
+    inputs:
+      branch-name:
+        required: true
+        type: string
+        description: Navn på branchen som skal slettes
+  workflow_call:
+    secrets:
+      GITHUB_TOKEN:
+        description: "Token for å kunne slette branch-deployments"
+        required: true
+    inputs:
+      branch-name:
+        required: true
+        type: string
+        description: Navn på branchen som er slettet
+
+jobs:
+  cleanup-deployment:
+    name: Rydd opp branch deployment
+    permissions:
+      contents: write
+      pages: write
+      deployments: write
+    runs-on: "ubuntu-latest"
+    steps:
+      # Trinn 1: Sjekk ut repository (gh-pages branch)
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        with:
+          ref: gh-pages
+          token: ${{ secrets.GITHUB_TOKEN || github.token }}
+
+      # Trinn 2: Konverter branch navn til URL-vennlig format
+      - name: Sett branch navn
+        id: branch-info
+        run: |
+          BRANCH_NAME="${{ inputs.branch-name }}"
+          # Fjern spesialtegn og gjør om til URL-vennlig format
+          SAFE_BRANCH=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9-]/-/g' | tr '[:upper:]' '[:lower:]')
+          echo "safe-branch=${SAFE_BRANCH}" >> $GITHUB_OUTPUT
+          echo "Sletter deployment for branch: ${SAFE_BRANCH}"
+
+      # Trinn 3: Slett branch-mappen fra gh-pages
+      - name: Slett branch-mappe
+        run: |
+          if [ -d "${{ steps.branch-info.outputs.safe-branch }}" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            
+            rm -rf "${{ steps.branch-info.outputs.safe-branch }}"
+            git add .
+            git commit -m "🗑️ Fjern storybook for slettet branch: ${{ inputs.branch-name }}"
+            git push
+            
+            echo "✅ Slettet mappe: ${{ steps.branch-info.outputs.safe-branch }}"
+          else
+            echo "ℹ️ Ingen mappe funnet for branch: ${{ steps.branch-info.outputs.safe-branch }}"
+          fi
+
+      # Trinn 4: Slett gamle deployments fra GitHub
+      - name: Slett gamle deployments
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # ratchet:actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN || github.token }}
+          script: |
+            const branchName = '${{ inputs.branch-name }}';
+
+            // Hent alle deployments
+            const deployments = await github.rest.repos.listDeployments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: branchName
+            });
+
+            // Slett hver deployment
+            for (const deployment of deployments.data) {
+              // Sett deployment til inactive først
+              await github.rest.repos.createDeploymentStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: deployment.id,
+                state: 'inactive'
+              });
+              
+              // Så slett deployment
+              await github.rest.repos.deleteDeployment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: deployment.id
+              });
+              
+              console.log(`Slettet deployment: ${deployment.id}`);
+            }
+
+            console.log(`✅ Ryddet opp ${deployments.data.length} deployment(s) for branch: ${branchName}`);

--- a/.github/workflows/deploy-storybook-manuelt.yml
+++ b/.github/workflows/deploy-storybook-manuelt.yml
@@ -1,0 +1,177 @@
+name: Deploy storybook manuelt
+on:
+  workflow_dispatch:
+    inputs:
+      package-manager:
+        required: true
+        type: choice
+        description: Package manager som skal brukes
+        options:
+          - pnpm
+          - yarn
+        default: pnpm
+      cache:
+        required: true
+        type: choice
+        description: Cache som skal brukes
+        options:
+          - turbo
+          - lerna
+        default: turbo
+      branch-name:
+        required: false
+        type: string
+        description: Navn på branchen som deployes (bruker current branch hvis tom)
+  workflow_call:
+    secrets:
+      READER_TOKEN:
+        description: "A token passed from the caller workflow"
+        required: true
+    inputs:
+      package-manager:
+        required: true
+        type: string
+        description: Package manager som skal brukes (pnpm|yarn)
+      cache:
+        required: true
+        type: string
+        description: Cache som skal brukes (turbo/lerna). Lerna er ikke implementert
+      branch-name:
+        required: false
+        type: string
+        description: Navn på branchen som deployes (brukes i URL)
+
+jobs:
+  deploy-storybook-branch:
+    name: Deploy storybook for branch
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    runs-on: "ubuntu-latest"
+    environment:
+      name: github-pages-branch
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      # Trinn 1: Sjekk ut repository
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+
+      # Trinn 2 Sett opp yarn/pnpm + node
+      - uses: navikt/fp-gha-workflows/.github/actions/setup-yarnrc@main
+        if: inputs.package-manager == 'yarn'
+        with:
+          npmAuthToken: ${{ secrets.READER_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - uses: navikt/fp-gha-workflows/.github/actions/setup-npmrc@main
+        if: inputs.package-manager == 'pnpm'
+        with:
+          npmAuthToken: ${{ secrets.READER_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # ratchet:pnpm/action-setup@v4
+        if: inputs.package-manager == 'pnpm'
+        with:
+          version: 10.28.0
+
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # ratchet:actions/setup-node@v6
+        with:
+          node-version: 22.17.1
+          cache: ${{ inputs.package-manager }}
+
+      # Trinn 3: Håndter caching for turbo builds
+      - name: Cache turbo build setup
+        if: inputs.cache == 'turbo'
+        id: hent-cache
+        uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # ratchet:actions/cache/restore@v5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      # Trinn 4: yarn install+build
+      - name: Installer avhengigheter med Yarn
+        if: inputs.package-manager == 'yarn'
+        run: |
+          yarn install --immutable
+      - name: Bygg Storybook med Yarn
+        if: inputs.package-manager == 'yarn'
+        run: yarn build:storybook
+
+      # Trinn 4: pnpm install+build
+      - name: Installer avhengigheter med Pnpm
+        if: inputs.package-manager == 'pnpm'
+        run: |
+          pnpm install --frozen-lockfile
+      - name: Bygg Storybook med Pnpm
+        if: inputs.package-manager == 'pnpm'
+        run: pnpm build:storybook
+
+      # Trinn 5: Bestem branch navn for URL
+      - name: Sett branch navn
+        id: branch-info
+        run: |
+          BRANCH_NAME="${{ inputs.branch-name }}"
+          if [ -z "$BRANCH_NAME" ]; then
+            BRANCH_NAME="${GITHUB_REF_NAME}"
+          fi
+          # Fjern spesialtegn og gjør om til URL-vennlig format
+          SAFE_BRANCH=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9-]/-/g' | tr '[:upper:]' '[:lower:]')
+          echo "safe-branch=${SAFE_BRANCH}" >> $GITHUB_OUTPUT
+          echo "Deployer til branch: ${SAFE_BRANCH}"
+
+      # Trinn 6: Flytt storybook til branch-spesifikk mappe
+      - name: Organiser filer for branch-deploy
+        run: |
+          mkdir -p deploy-temp/${{ steps.branch-info.outputs.safe-branch }}
+          mv ./.storybook-static-build/* deploy-temp/${{ steps.branch-info.outputs.safe-branch }}/
+
+          # Lag index.html på rot-nivå som viser tilgjengelige branches
+          cat > deploy-temp/index.html << 'EOF'
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <title>Storybook Branches</title>
+            <style>
+              body { font-family: sans-serif; max-width: 800px; margin: 50px auto; padding: 20px; }
+              h1 { color: #333; }
+              .branch { 
+                padding: 10px; 
+                margin: 10px 0; 
+                background: #f5f5f5; 
+                border-radius: 4px;
+              }
+              a { color: #0066cc; text-decoration: none; }
+              a:hover { text-decoration: underline; }
+            </style>
+          </head>
+          <body>
+            <h1>Storybook Deploy - Branch: ${{ steps.branch-info.outputs.safe-branch }}</h1>
+            <div class="branch">
+              <a href="./${{ steps.branch-info.outputs.safe-branch }}/">📖 Se Storybook for ${{ steps.branch-info.outputs.safe-branch }}</a>
+            </div>
+          </body>
+          </html>
+          EOF
+
+      # Trinn 7: Konfigurer og deploy til GitHub Pages
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # ratchet:actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@7b1a764d45c48632c6b24a0339c27f5614fb0b # ratchet:actions/upload-pages-artifact@v4
+        with:
+          path: ./deploy-temp
+
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # ratchet:actions/deploy-pages@v4
+        id: deployment
+
+      # Trinn 8: Lagre turbo cache
+      - name: Lagre turbo cache
+        if: always() && inputs.cache == 'turbo' && steps.hent-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # ratchet:actions/cache/save@v5
+        with:
+          key: ${{ steps.hent-cache.outputs.cache-primary-key }}
+          path: .turbo
+
+      # Trinn 9: Gi tilbakemelding om URL
+      - name: Deployment info
+        run: |
+          echo "✅ Storybook deployet til: ${{ steps.deployment.outputs.page_url }}${{ steps.branch-info.outputs.safe-branch }}/"

--- a/.github/workflows/deploy-storybook-manuelt.yml
+++ b/.github/workflows/deploy-storybook-manuelt.yml
@@ -21,7 +21,7 @@ on:
       branch-name:
         required: false
         type: string
-        description: Navn på branchen som deployes (bruker current branch hvis tom)
+        description: Navn på branchen som deployes (ikke main/master - bruker current branch hvis tom)
   workflow_call:
     secrets:
       READER_TOKEN:
@@ -46,15 +46,26 @@ jobs:
     name: Deploy storybook for branch
     permissions:
       contents: write
-      pages: write
-      id-token: write
     runs-on: "ubuntu-latest"
-    environment:
-      name: github-pages-branch
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       # Trinn 1: Sjekk ut repository
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+
+      # Trinn 1.5: Sjekk at vi ikke deployer main/master
+      - name: Sjekk at branch ikke er main/master
+        run: |
+          BRANCH_NAME="${{ inputs.branch-name }}"
+          if [ -z "$BRANCH_NAME" ]; then
+            BRANCH_NAME="${GITHUB_REF_NAME}"
+          fi
+
+          if [ "$BRANCH_NAME" = "main" ] || [ "$BRANCH_NAME" = "master" ]; then
+            echo "❌ Denne workflow-en skal ikke brukes for main/master branches!"
+            echo "Bruk den vanlige deploy-storybook.yml workflowen for main/master."
+            exit 1
+          fi
+
+          echo "✅ Branch '$BRANCH_NAME' er OK for branch-deploy"
 
       # Trinn 2 Sett opp yarn/pnpm + node
       - uses: navikt/fp-gha-workflows/.github/actions/setup-yarnrc@main
@@ -119,51 +130,17 @@ jobs:
           echo "safe-branch=${SAFE_BRANCH}" >> $GITHUB_OUTPUT
           echo "Deployer til branch: ${SAFE_BRANCH}"
 
-      # Trinn 6: Flytt storybook til branch-spesifikk mappe
-      - name: Organiser filer for branch-deploy
-        run: |
-          mkdir -p deploy-temp/${{ steps.branch-info.outputs.safe-branch }}
-          mv ./.storybook-static-build/* deploy-temp/${{ steps.branch-info.outputs.safe-branch }}/
-
-          # Lag index.html på rot-nivå som viser tilgjengelige branches
-          cat > deploy-temp/index.html << 'EOF'
-          <!DOCTYPE html>
-          <html>
-          <head>
-            <title>Storybook Branches</title>
-            <style>
-              body { font-family: sans-serif; max-width: 800px; margin: 50px auto; padding: 20px; }
-              h1 { color: #333; }
-              .branch { 
-                padding: 10px; 
-                margin: 10px 0; 
-                background: #f5f5f5; 
-                border-radius: 4px;
-              }
-              a { color: #0066cc; text-decoration: none; }
-              a:hover { text-decoration: underline; }
-            </style>
-          </head>
-          <body>
-            <h1>Storybook Deploy - Branch: ${{ steps.branch-info.outputs.safe-branch }}</h1>
-            <div class="branch">
-              <a href="./${{ steps.branch-info.outputs.safe-branch }}/">📖 Se Storybook for ${{ steps.branch-info.outputs.safe-branch }}</a>
-            </div>
-          </body>
-          </html>
-          EOF
-
-      # Trinn 7: Konfigurer og deploy til GitHub Pages
-      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # ratchet:actions/configure-pages@v5
-
-      - uses: actions/upload-pages-artifact@7b1a764d45c48632c6b24a0339c27f5614fb0b # ratchet:actions/upload-pages-artifact@v4
+      # Trinn 6: Deploy til GitHub Pages (uten å slette eksisterende innhold)
+      - name: Deploy til GitHub Pages
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # ratchet:peaceiris/actions-gh-pages@v4
         with:
-          path: ./deploy-temp
+          github_token: ${{ secrets.GITHUB_TOKEN || github.token }}
+          publish_dir: ./.storybook-static-build
+          destination_dir: ${{ steps.branch-info.outputs.safe-branch }}
+          keep_files: true # VIKTIG: Behold eksisterende filer (beskytter main/master)
+          commit_message: "🚀 Deploy storybook for branch: ${{ inputs.branch-name }}"
 
-      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # ratchet:actions/deploy-pages@v4
-        id: deployment
-
-      # Trinn 8: Lagre turbo cache
+      # Trinn 7: Lagre turbo cache
       - name: Lagre turbo cache
         if: always() && inputs.cache == 'turbo' && steps.hent-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # ratchet:actions/cache/save@v5
@@ -171,7 +148,9 @@ jobs:
           key: ${{ steps.hent-cache.outputs.cache-primary-key }}
           path: .turbo
 
-      # Trinn 9: Gi tilbakemelding om URL
+      # Trinn 8: Gi tilbakemelding om URL
       - name: Deployment info
         run: |
-          echo "✅ Storybook deployet til: ${{ steps.deployment.outputs.page_url }}${{ steps.branch-info.outputs.safe-branch }}/"
+          REPO_NAME="${{ github.repository }}"
+          REPO_SHORT="${REPO_NAME#*/}"
+          echo "✅ Storybook deployet til: https://${{ github.repository_owner }}.github.io/${REPO_SHORT}/${{ steps.branch-info.outputs.safe-branch }}/"


### PR DESCRIPTION
- Workflow som gjør at man kan manuelt deploye brancher som ikke er master  
main til storybook og at de da får et ekstra path i url som er branchnavnet. 
- Workflow som gjør at man sletter story book-deploys som tilhører brancher som ikke lenger lever

- OBS: Koden er laget med hjelp av CoPilot