### PR TITLE
fix: pass bake metadata via env var to avoid shell injection

### DIFF
--- a/.github/actions/build-push-docker-bake/action.yml
+++ b/.github/actions/build-push-docker-bake/action.yml
@@ -94,8 +94,10 @@ runs:
       if: inputs.push-image == 'true'
       shell: bash
       id: digest_step
+      env:
+        BAKE_METADATA: ${{ steps.build_push.outputs.metadata }}
       run: |
-        echo "digest=$(echo '${{ steps.build_push.outputs.metadata }}' | jq -r '.[]."containerimage.digest"')" >> $GITHUB_OUTPUT
+        echo "digest=$(echo "$BAKE_METADATA" | jq -r '.[]."containerimage.digest"')" >> $GITHUB_OUTPUT
 
     - name: Generate SBOM, attest and sign image
       if: inputs.push-image == 'true'


### PR DESCRIPTION
The metadata output from docker/bake-action includes the full git commit message. When substituted directly into a single-quoted bash string via ${{ }}, single quotes in commit messages break the shell syntax. Using an env variable lets GitHub Actions safely pass the value without shell interpretation issues.