### PR TITLE
fix(knip-it): bruk pnpm exec for knip

### DIFF
--- a/.github/actions/knip-it/action.yml
+++ b/.github/actions/knip-it/action.yml
@@ -58,7 +58,7 @@ runs:
         if [ "${{ inputs.package-manager }}" = "yarn" ]; then
           yarn knip --no-exit-code --reporter=markdown > knip-report.md
         elif [ "${{ inputs.package-manager }}" = "pnpm" ]; then
-          pnpm knip --no-exit-code --reporter=markdown > knip-report.md
+          pnpm exec knip --no-exit-code --reporter=markdown > knip-report.md
         else
           echo "Unsupported package manager: ${{ inputs.package-manager }}"
           exit 1


### PR DESCRIPTION
## Sammendrag
- Bruker `pnpm exec knip` i knip-it-actionen slik at output raporteres lik som med yarn. 

Differansen på den genererte markdown filen:
```diff
-
-> fp-selvbetjening@ knip /Users/Siri.Mykland/dev/foreldrepengesoknad
-> knip --no-exit-code --reporter=markdown
-
# Knip report
```
