### PR TITLE
TFP-6363: dokumenter at deploy.yml krever id-token og ikke trenger secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,36 +22,36 @@ on:
       image:
         required: true
         type: string
-        description: 'Image tag to deploy (example 2023.03.10.080433-f821119)'
+        description: "Image tag to deploy (example 2023.03.10.080433-f821119)"
       cluster:
         required: true
         type: string
-        description: 'The cluster to deploy to (dev-fss|dev-gcp|prod-fss|prod-gcp)'
+        description: "The cluster to deploy to (dev-fss|dev-gcp|prod-fss|prod-gcp)"
       namespace:
         required: false
         type: string
-        description: 'The namespace to deploy to'
-        default: 'teamforeldrepenger'
+        description: "The namespace to deploy to"
+        default: "teamforeldrepenger"
       gar:
         required: false
         type: string
-        description: 'The namespace to deploy to'
-        default: 'false'
+        description: "Whether to deploy to Google Artifact Registry (GAR) or not. Default is false"
+        default: "false"
       naiserator_file:
         required: false
         type: string
-        description: 'The naiserator.yaml file name in .deploy/ to use'
-        default: 'naiserator.yaml'
+        description: "The naiserator.yaml file name in .deploy/ to use"
+        default: "naiserator.yaml"
       deploy_context:
         required: false
         type: string
-        description: 'The deploy context /'
-        default: ''
+        description: "The deploy context /"
+        default: ""
       image_suffix:
         required: false
         type: string
-        description: 'The suffix of the image to be deployed'
-        default: ''
+        description: "The suffix of the image to be deployed"
+        default: ""
       branch:
         required: false
         type: string
@@ -63,11 +63,12 @@ jobs:
   deploy:
     name: deploy
     environment: ${{ inputs.cluster }}:${{ inputs.namespace }}${{ inputs.image_suffix }}
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
         with:
           ref: ${{ (inputs.branch != '' && inputs.branch) || '' }}
+
       - name: Deploy ${{ inputs.cluster }} fra Github
         if: inputs.gar == 'false'
         uses: nais/deploy/actions/deploy@849e900e3cfa7faf7ad1532bb3a3e6499c932199 # ratchet:nais/deploy/actions/deploy@v2
@@ -76,12 +77,14 @@ jobs:
           CLUSTER: ${{ inputs.cluster }}
           RESOURCE: .deploy/${{ inputs.naiserator_file }}
           VARS: .deploy/${{ inputs.cluster }}-${{ inputs.namespace }}.json
+
       - name: Login GAR
         uses: nais/login@40b72a35a18ddf2ad74b632461139ab838cc2a2f # ratchet:nais/login@v0
         if: inputs.gar == 'true'
         id: login
         with:
           team: ${{ inputs.namespace }}
+
       - name: Deploy ${{ inputs.cluster }} fra GAR
         if: inputs.gar == 'true'
         uses: nais/deploy/actions/deploy@849e900e3cfa7faf7ad1532bb3a3e6499c932199 # ratchet:nais/deploy/actions/deploy@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,21 @@
 name: Deploy
+# Gjenbrukbar deploy-workflow.
+# Eksempel på bruk:
+# ```
+# deploy-dev:
+#    name: Deploy dev
+#    permissions:
+#      id-token: write
+#    if: github.ref_name == 'master'
+#    needs: [build-app]
+#    uses: navikt/fp-gha-workflows/.github/workflows/deploy.yml@main
+#    with:
+#      gar: true
+#      image: ${{ needs.build-app.outputs.build-version }}
+#      cluster: dev-fss
+#```
+# Autentisering skjer via OIDC – kallende jobb må sette `permissions: { id-token: write }`.
+# Workflowen bruker ingen secrets, så `secrets`-blokken er ikke nødvendig.
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Legger til en overordnet kommentar-header i `deploy.yml` som dokumenterer at:

- Autentisering mot NAIS skjer via **OIDC** – kallende jobb må sette `permissions: { id-token: write }`.
- Workflowen bruker **ingen secrets**, så `secrets: inherit` i kalleren er ikke nødvendig.

Inkluderer et bruks-eksempel i kommentaren.

Bakgrunn: verifisert i navikt/fp-swagger#385 at deploy fungerer uten `secrets: inherit`.
Neste steg er å fjerne `secrets: inherit` fra alle konsumenter av deploy.yml.

Gjerne ta en titt på denne også: https://github.com/navikt/fp-sak/pull/7966 

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>