### PR TITLE
TFP-6363: la setup-yarnrc bruke GITHUB_TOKEN i stedet for READER_TOKEN

### DIFF
--- a/.github/actions/setup-yarnrc/action.yml
+++ b/.github/actions/setup-yarnrc/action.yml
@@ -3,9 +3,10 @@ name: Setup yarn config
 description: Konfigurerer yarn auth config for å hente `@navikt/*` og `@nais/*`-pakker i github package registry
 inputs:
   npmAuthToken:
-    description: Token med `packages:read` for navikt organisasjonen
-    required: true
-    deprecationMessage: "Bruk `GITHUB_TOKEN` med `permissions: { packages: read }` i stedet for en PAT/READER_TOKEN."
+    description: "Token med `packages:read`. Default er `GITHUB_TOKEN` – kallende jobb må sette `permissions: { packages: read }`."
+    required: false
+    default: ${{ github.token }}
+    deprecationMessage: "Ikke send inn en PAT/READER_TOKEN. La feltet stå tomt så brukes `GITHUB_TOKEN` (krever `permissions: { packages: read }`)."
 
 runs:
   using: composite

--- a/.github/actions/setup-yarnrc/action.yml
+++ b/.github/actions/setup-yarnrc/action.yml
@@ -1,9 +1,11 @@
+# Bruk `GITHUB_TOKEN` med `permissions: { packages: read }` i den kallende jobben for å hente pakker.
 name: Setup yarn config
 description: Konfigurerer yarn auth config for å hente `@navikt/*` og `@nais/*`-pakker i github package registry
 inputs:
   npmAuthToken:
     description: Token med `packages:read` for navikt organisasjonen
     required: true
+    deprecationMessage: "Bruk `GITHUB_TOKEN` med `permissions: { packages: read }` i stedet for en PAT/READER_TOKEN."
 
 runs:
   using: composite


### PR DESCRIPTION
## Hva
Gjør `setup-yarnrc`-actionen klar for å brukes med kortlevd `GITHUB_TOKEN` i stedet for PAT/`READER_TOKEN`:

- `npmAuthToken` gjort **valgfri** med default `${{ github.token }}` – kallere kan droppe å sende inn token
- `deprecationMessage` som nudger bort fra å sende inn en PAT
- Kommentar øverst + i `description` om at kallende jobb må sette `permissions: { packages: read }`

## Hvorfor
Del av TFP-6363 (begrense secret-arv og PAT-bruk). `GITHUB_TOKEN` er short-lived og følger jobbens `permissions`, mens `READER_TOKEN` er en langlevd PAT-servicebruker vi ønsker å fase ut der det går.

## Testet ✅
Verifisert i to test-PR-er med **yarn-cache deaktivert** (for å tvinge reell autentisert henting – ellers ville `.yarn/cache`-restore gitt falsk grønn):

| Repo | Test-PR | Pakker | Resultat |
|------|---------|--------|----------|
| fp-frontend | navikt/fp-frontend#7526 | `@navikt/*` + cross-org `@nais/apm` | ✅ pass |
| ft-frontend-saksbehandling | navikt/ft-frontend-saksbehandling#4404 | `@navikt/*` | ✅ pass |

**Funn:** `GITHUB_TOKEN` med `packages: read` klarer å hente både `@navikt/*` og cross-org `@nais/apm` fra `npm.pkg.github.com`. Ingen 401/403 i loggene.

> Merk: gjelder **npm-pakker** via GitHub Packages. GHCR (container images) støtter fortsatt kun PAT.

## Bakoverkompatibilitet
Ingen breaking change – eksisterende kallere som fortsatt sender `npmAuthToken: ${{ secrets.READER_TOKEN }}` fungerer som før (får kun en deprecation-warning).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>