### PR TITLE
TFP-6363: la knip-it bruke GITHUB_TOKEN i stedet for READER_TOKEN

### DIFF
--- a/.github/actions/knip-it/action.yml
+++ b/.github/actions/knip-it/action.yml
@@ -2,8 +2,10 @@ name: Kjør Knip
 description: Kjører Knip for å finne ubrukt kode og eksporter
 inputs:
   npm-auth-token:
-    description: Token med `packages:read` for navikt organisasjonen.
-    required: true
+    description: "Token med `packages:read`. Default er `GITHUB_TOKEN` – kallende jobb må sette `permissions: { packages: read }`."
+    required: false
+    default: ${{ github.token }}
+    deprecationMessage: "Ikke send inn en PAT/READER_TOKEN. La feltet stå tomt så brukes `GITHUB_TOKEN` (krever `permissions: { packages: read }`)."
   package-manager:
     description: Package manager som skal brukes (pnpm|yarn).
     required: true


### PR DESCRIPTION
## Hva
Gjør `npm-auth-token` i `knip-it`-actionen **valgfri** med default `${{ github.token }}`, på samme måte som `setup-yarnrc` (#476). Kallere kan da droppe å sende inn en PAT/`READER_TOKEN`.

- `required: true` → `required: false`, `default: ${{ github.token }}`
- `deprecationMessage` som nudger bort fra PAT

## Krav i kallende jobb
Jobben som kaller `knip-it` må sette `permissions: { packages: read }` (for at `GITHUB_TOKEN` skal kunne lese pakkene i `yarn install`).

## Bakoverkompatibilitet
Ingen breaking change – kallere som fortsatt sender `npm-auth-token: ${{ secrets.READER_TOKEN }}` fungerer som før (kun deprecation-warning).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>