### PR TITLE
TFP-6363: rydd opp npm-auth i knip-it (pnpm)

### DIFF
--- a/.github/actions/knip-it/action.yml
+++ b/.github/actions/knip-it/action.yml
@@ -27,11 +27,6 @@ runs:
       with:
         npmAuthToken: ${{ inputs.npm-auth-token }}
 
-    - uses: navikt/fp-gha-workflows/.github/actions/setup-npmrc@main # ratchet:exclude
-      if: inputs.package-manager == 'pnpm'
-      with:
-        npmAuthToken: ${{ inputs.npm-auth-token }}
-
     - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # ratchet:pnpm/action-setup@v6.0.10
       if: inputs.package-manager == 'pnpm'
 
@@ -39,6 +34,8 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ inputs.package-manager }}
+        registry-url: 'https://npm.pkg.github.com'
+        scope: '@navikt'
 
     - name: Yarn install
       if: inputs.package-manager == 'yarn'
@@ -49,8 +46,9 @@ runs:
     - name: Pnpm install
       if: inputs.package-manager == 'pnpm'
       shell: bash
-      run: |
-        pnpm install --frozen-lockfile
+      run: pnpm install --frozen-lockfile --ignore-scripts
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
 
     - name: Run Knip
       id: knip

--- a/.github/actions/knip-it/action.yml
+++ b/.github/actions/knip-it/action.yml
@@ -1,11 +1,6 @@
 name: Kjør Knip
 description: Kjører Knip for å finne ubrukt kode og eksporter
 inputs:
-  npm-auth-token:
-    description: "Token med `packages:read`. Default er `GITHUB_TOKEN` – kallende jobb må sette `permissions: { packages: read }`."
-    required: false
-    default: ${{ github.token }}
-    deprecationMessage: "Ikke send inn en PAT/READER_TOKEN. La feltet stå tomt så brukes `GITHUB_TOKEN` (krever `permissions: { packages: read }`)."
   package-manager:
     description: Package manager som skal brukes (pnpm|yarn).
     required: true
@@ -14,8 +9,10 @@ inputs:
     default: "26"
     required: false
   github-token:
-    description: Token som skal brukes for å publisere en PR kommentar.
-    required: true
+    description: "Token med `packages:read` og tilgang til å publisere en PR-kommentar. Default er `GITHUB_TOKEN` – kallende jobb må sette `permissions: { packages: read, pull-requests: write }`."
+    required: false
+    default: ${{ github.token }}
+    deprecationMessage: "Ikke send inn en PAT/READER_TOKEN. La feltet stå tomt så brukes `GITHUB_TOKEN` (krever `permissions: { packages: read, pull-requests: write }`)."
 
 runs:
   using: composite
@@ -25,7 +22,7 @@ runs:
     - uses: navikt/fp-gha-workflows/.github/actions/setup-yarnrc@main # ratchet:exclude
       if: inputs.package-manager == 'yarn'
       with:
-        npmAuthToken: ${{ inputs.npm-auth-token }}
+        npmAuthToken: ${{ inputs.github-token }}
 
     - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # ratchet:pnpm/action-setup@v6.0.10
       if: inputs.package-manager == 'pnpm'
@@ -48,7 +45,7 @@ runs:
       shell: bash
       run: pnpm install --frozen-lockfile --ignore-scripts
       env:
-        NODE_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        NODE_AUTH_TOKEN: ${{ inputs.github-token }}
 
     - name: Run Knip
       id: knip


### PR DESCRIPTION
Følger opp #477.

## Hva
- Fjerner `setup-npmrc`-steget i knip-it-actionen.
- Setter i stedet `registry-url: https://npm.pkg.github.com` + `scope: @navikt` på `setup-node`, slik at pnpm autentiserer via `NODE_AUTH_TOKEN`.
- Bruker `inputs.npm-auth-token` konsekvent som token-kilde (defaulter til `GITHUB_TOKEN`), i stedet for blanding av `github-token`/`secrets`.

## Hvorfor
Samler npm-auth på én input (`npm-auth-token`) og fjerner dupliseringen av token-kilder. `setup-npmrc` beholdes i repoet (brukes fortsatt av `deploy-storybook.yml`).