### PR TITLE
TFP-6363: dokumenter permissions per gjenbrukbar workflow og stram inn over-grants

### DIFF
--- a/.github/workflows/build-app-no-db.yml
+++ b/.github/workflows/build-app-no-db.yml
@@ -1,4 +1,5 @@
 name: Build app
+# Gjenbrukbar workflow: bygger og tester en Maven-app, og bygger/pusher evt. Docker-image.
 on:
   workflow_call:
     inputs:
@@ -45,9 +46,9 @@ jobs:
   build-and-test:
     name: Build and test
     permissions:
-      contents: read
-      packages: write
-      id-token: write
+      contents: read    # checkout av koden
+      packages: read    # lese private @navikt Maven-pakker fra GitHub Packages under `mvn install`
+      id-token: write   # OIDC mot NAIS/GAR for docker login + push + signering/attestering
     runs-on: ${{ (github.event.pull_request.user.login == 'dependabot[bot]' && 'ubuntu-latest') || inputs.runs-on }}
     env:
       TZ: "Europe/Oslo"

--- a/.github/workflows/build-feature.yml
+++ b/.github/workflows/build-feature.yml
@@ -1,4 +1,5 @@
 name: Build app
+# Gjenbrukbar workflow: kjører `mvn verify` (bygg + test), uten database.
 on:
   workflow_call:
     inputs:
@@ -30,6 +31,8 @@ on:
 jobs:
   build-and-test:
     name: Build and test
+    permissions:
+      contents: read    # checkout av koden (public @navikt Maven-deps leses uten packages-perm)
     runs-on: ${{ (github.event.pull_request.user.login == 'dependabot[bot]' && 'ubuntu-latest') || inputs.runs-on }}
     outputs:
       build-version: ${{ steps.build-and-test.outputs.build-version }}

--- a/.github/workflows/cdn-upload.yml
+++ b/.github/workflows/cdn-upload.yml
@@ -1,4 +1,7 @@
 name: Upload assets to CDN
+# Gjenbrukbar workflow: henter bygde assets fra et Docker-image og laster dem opp til NAIS CDN.
+# Ingen checkout og ingen skrivetilgang til repoet trengs, derfor ingen contents-permission.
+# Bruker ingen secrets.
 on:
   workflow_call:
     inputs:
@@ -25,8 +28,7 @@ jobs:
     name: Upload assets to CDN
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      id-token: write
+      id-token: write   # OIDC mot NAIS for `nais/login` og `cdn-upload`
     steps:
       - name: Login GAR
         uses: nais/login@40b72a35a18ddf2ad74b632461139ab838cc2a2f # ratchet:nais/login@v0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,10 +1,5 @@
 name: "Statisk Kode Analyse"
-# Autentiserer med den innebygde GITHUB_TOKEN (READER_TOKEN er utfasing, se under).
-# Permissions settes i job-blokken under. Kallende jobb må gi følgende permissions:
-#   permissions:
-#     contents: read          # checkout av koden
-#     security-events: write  # laste opp CodeQL/SARIF-resultater til Code scanning
-#     actions: read           # kun strengt nødvendig for private repoer (CodeQL leser workflow-run status)
+# Gjenbrukbar workflow: CodeQL statisk analyse (+ evt. Sonar-scan).
 on:
   workflow_call:
     secrets:
@@ -25,7 +20,7 @@ on:
       use-reader:
         required: false
         type: boolean
-        description: Hvilket token skal brukes? READER_TOKEN må sendes inn eksplisitt hvis true.
+        description: Utfaset/ignorert – bygg bruker alltid GITHUB_TOKEN.
         default: false
       sonar:
         required: false
@@ -49,24 +44,18 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: ${{ (github.event.pull_request.user.login == 'dependabot[bot]' && 'ubuntu-latest') || inputs.runs-on }}
     permissions:
-      actions: read
-      contents: read
-      security-events: write
+      actions: read           # CodeQL trenger å lese workflow-runs for private repoer
+      contents: read          # checkout av koden
+      security-events: write  # laste opp CodeQL/SARIF-resultater til Code scanning
     steps:
       - name: Sjekk påkrevde secrets
         if: inputs.language == 'java'
         env:
           SONAR: ${{ inputs.sonar }}
-          USE_READER: ${{ inputs.use-reader }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          READER_TOKEN: ${{ secrets.READER_TOKEN }}
         run: |
           if [[ "$SONAR" == "true" && -z "$SONAR_TOKEN" ]]; then
             echo "::error::SONAR_TOKEN må være satt når sonar: true. Legg til secreten i kallende repo (eller sett sonar: false)."
-            exit 1
-          fi
-          if [[ "$USE_READER" == "true" && -z "$READER_TOKEN" ]]; then
-            echo "::error::READER_TOKEN må være satt når use-reader: true. Send inn secreten fra kallende workflow (eller sett use-reader: false)."
             exit 1
           fi
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
@@ -91,7 +80,7 @@ jobs:
           t-2c: ${{ inputs.t-2c }}
           profil: -Psonar
         env:
-          GITHUB_TOKEN: ${{ (github.actor != 'dependabot[bot]' && inputs.use-reader && secrets.READER_TOKEN) || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
       - name: Autobuild
         if: inputs.language != 'java'

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,11 +1,5 @@
 name: Deploy storybook
 # Autentiserer mot npm.pkg.github.com med den innebygde GITHUB_TOKEN.
-# Kallende jobb må gi følgende permissions:
-#   permissions:
-#     contents: read    # checkout
-#     packages: read    # lese @navikt-pakker fra GitHub Packages
-#     pages: write      # deploy til GitHub Pages
-#     id-token: write   # OIDC for deploy-pages
 on:
   workflow_call:
     inputs:
@@ -27,10 +21,10 @@ jobs:
   deploy-storybook:
     name: Deploy storybook ${{ inputs.package-manager }}
     permissions:
-      contents: read
-      packages: read
-      pages: write
-      id-token: write
+      contents: read    # checkout
+      packages: read    # lese @navikt-pakker fra GitHub Packages
+      pages: write      # deploy til GitHub Pages
+      id-token: write   # OIDC for deploy-pages
     runs-on: "ubuntu-latest"
     environment:
       name: github-pages

--- a/.github/workflows/mvn-dependency-submission.yml
+++ b/.github/workflows/mvn-dependency-submission.yml
@@ -1,4 +1,5 @@
 name: Maven Dependency Submission
+# Gjenbrukbar workflow: sender inn Maven-avhengighetsgrafen til GitHub Dependency Graph.
 on:
   workflow_call:
     inputs:
@@ -14,7 +15,7 @@ jobs:
       GITHUB_TOKEN: ${{ (github.actor != 'dependabot[bot]' && secrets.READER_TOKEN) || secrets.GITHUB_TOKEN }}
       GITHUB_ACTOR: ${{ github.actor }}
     permissions:
-      contents: write
+      contents: write   # submitte dependency snapshot via Dependency Submission API
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
       - name: Set up JDK-${{ inputs.java-version }} with cache

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,12 +1,13 @@
 name: Release draft update
+# Gjenbrukbar workflow: oppdaterer utkast til release notes med release-drafter.
 on:
   workflow_call:
 jobs:
   update_release_draft:
     name: Release draft
     permissions:
-      contents: write
-      pull-requests: read
+      contents: write        # opprette/oppdatere release-draft (GitHub Releases)
+      pull-requests: read    # lese merged PR-er for å generere release notes
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # ratchet:release-drafter/release-drafter@v7.7.0

--- a/.github/workflows/release-feature.yml
+++ b/.github/workflows/release-feature.yml
@@ -1,4 +1,5 @@
 name: Release feature
+# Gjenbrukbar workflow: setter release-versjon og publiserer (`mvn deploy`) artefakter.
 on:
   workflow_call:
     inputs:
@@ -39,8 +40,8 @@ jobs:
   build:
     name: Release
     permissions:
-      contents: read
-      packages: write
+      contents: read    # checkout av koden
+      packages: write   # publisere Maven-artefakter til GitHub Packages (`mvn deploy`)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Hva
Dokumenterer permission-behovet for de gjenbrukbare workflowsene i `fp-gha-workflows`, strammer inn åpenbare over-grants, og faser ut `READER_TOKEN`-referanser.

- **Permission-begrunnelser ligger nå inline** som kommentar ved hver linje i selve `permissions:`-blokken (ikke lenger i en topp-blokk).
- **READER_TOKEN-referanser fjernet fra kommentarer.** I `codeql.yml` er også selve READER_TOKEN-sjekken og -bruken fjernet (bruker `GITHUB_TOKEN`); `use-reader`-inputen beholdes som utfaset no-op til alle kallere er oppdatert.

## Endringer i permission-verdier

| Workflow | Endring | Type |
|---|---|---|
| build-app-no-db | `packages: write` → `packages: read` | innstramming |
| cdn-upload | fjernet ubrukt `contents: read` (kun `id-token: write` igjen) | innstramming |
| build-feature | la til eksplisitt least-privilege `permissions: { contents: read }` | ny block |
| codeql, release-feature, release-drafter, mvn-dependency-submission, deploy-storybook | **ingen verdiendring** – kun inline-kommentarer | dok |

## Trygt å merge — konsument-analyse

**Mekanikk:** En gjenbrukbar (`workflow_call`) workflow kan aldri be om **mer** permissions enn kaller-jobben gir – gjør den det, feiler kjøringen. Å be om **like mye eller mindre** er alltid trygt. Alle verdiendringene under er reduksjoner eller matcher det kallerne allerede gir.

- **build-app-no-db (`packages: write` → `read`)** — ✅ trygt. Verifisert at **alle** konsumenter gir `packages: write` i kaller-jobben (write ⊇ read). Workflowen gjør kun `mvn install` (les) + Docker-push til GAR via OIDC (`id-token: write`); ingen `mvn deploy`/publisering til GitHub Packages, så `write` var uansett unødvendig.
- **cdn-upload (fjernet `contents: read`)** — ✅ trygt. Ren reduksjon; workflowen sjekker ikke ut kode.
- **build-feature (kun `contents: read`)** — ✅ trygt. Alle 19 konsumenter gir `contents: read` i kaller-jobben. `packages: read` ble bevisst **ikke** krevd: 14 av 19 konsumenter gir kun `contents: read`, og de bygger grønt i dag med `packages: none` — som beviser at public @navikt-deps leses uten packages-perm. (Å kreve `packages: read` her ville brutt de 14.)
- **codeql m.fl.** — ✅ trygt. Permission-verdiene er uendret; kun kommentarer er flyttet inline.

Ingen konsument trenger endring for at denne PR-en skal være bakoverkompatibel.

## Verifisering
- YAML validert for alle endrede filer.
- Konsument-permissions kartlagt for både `build-app-no-db` (22 repo) og `build-feature` (19 repo).
- zizmor kjørt offline – ingen nye funn (kun pre-eksisterende `template-injection` i `run`-blokker, urørt av denne PR-en).

Del av TFP-6363 (redusere READER_TOKEN / stramme inn token- og permission-hygiene).
