### PR TITLE
Deprecate READER_TOKEN secret i codeql-workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,10 @@
 name: "Statisk Kode Analyse"
+# Autentiserer med den innebygde GITHUB_TOKEN (READER_TOKEN er utfasing, se under).
+# Permissions settes i job-blokken under. Kallende jobb må gi følgende permissions:
+#   permissions:
+#     contents: read          # checkout av koden
+#     security-events: write  # laste opp CodeQL/SARIF-resultater til Code scanning
+#     actions: read           # kun strengt nødvendig for private repoer (CodeQL leser workflow-run status)
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
         with:
-          fetch-depth: 0 # checkout gir shallow copy - fetch-depth: 0 vil tilgjengeliggjøre tags
+          fetch-depth: 0 # full historikk trengs for korrekt Sonar blame/nykode-analyse (og tilgjengeliggjør tags)
       - name: Initialize CodeQL
         uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # ratchet:github/codeql-action/init@v4.37.7
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,7 @@ on:
   workflow_call:
     secrets:
       READER_TOKEN:
-        description: "DEPRECATED: A token passed from the caller workflow. Denne secret-en er utfasing og vil bli fjernet i en fremtidig versjon. Bruk GITHUB_TOKEN i stedet."
+        description: "UTFASING: Token sendt fra kallende workflow. Denne secret-en fases ut og vil bli fjernet i en fremtidig versjon. Bruk GITHUB_TOKEN i stedet."
         required: false
     inputs:
       java-version:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,8 @@ on:
   workflow_call:
     secrets:
       READER_TOKEN:
-        description: "A token passed from the caller workflow"
-        required: true
+        description: "DEPRECATED: A token passed from the caller workflow. Denne secret-en er utfasing og vil bli fjernet i en fremtidig versjon. Bruk GITHUB_TOKEN i stedet."
+        required: false
     inputs:
       java-version:
         required: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,10 +7,6 @@ name: "Statisk Kode Analyse"
 #     actions: read           # kun strengt nødvendig for private repoer (CodeQL leser workflow-run status)
 on:
   workflow_call:
-    secrets:
-      READER_TOKEN:
-        description: "UTFASING: Token sendt fra kallende workflow. Denne secret-en fases ut og vil bli fjernet i en fremtidig versjon. Bruk GITHUB_TOKEN i stedet."
-        required: false
     inputs:
       java-version:
         required: false
@@ -25,7 +21,7 @@ on:
       use-reader:
         required: false
         type: boolean
-        description: Hvilket token skal brukes?
+        description: Hvilket token skal brukes? READER_TOKEN må sendes inn eksplisitt hvis true.
         default: false
       sonar:
         required: false
@@ -87,8 +83,9 @@ jobs:
       - name: Perform Sonar Analysis
         if: inputs.language == 'java' && inputs.sonar
         run: |
-          mvn jacoco:report jacoco:report-aggregate sonar:sonar ${{ inputs.t-2c }} -e -q -B -Djacoco.destFile=$(pwd)/target/jacoco.exec -Psonar
+          mvn jacoco:report jacoco:report-aggregate sonar:sonar ${T_2C} -e -q -B -Djacoco.destFile=$(pwd)/target/jacoco.exec -Psonar
         env:
+          T_2C: ${{ inputs.t-2c }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}


### PR DESCRIPTION
## Hva

Faser ut `READER_TOKEN`-secreten i `codeql.yml`:

- `required: true` → `required: false`
- Legger til deprecation-melding i `description`

## Hvorfor

`READER_TOKEN` er under utfasing. `GITHUB_TOKEN` skal brukes i stedet. Ved å sette secreten til valgfri unngår vi at kallende workflows tvinges til å oppgi den.

## Bakoverkompatibilitet

Ikke-brytende. Callers som fortsatt sender `READER_TOKEN` fungerer som før; nye callers slipper å oppgi den.