### PR TITLE
Deklarer SONAR_TOKEN som secret input i codeql-workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,10 @@ name: "Statisk Kode Analyse"
 #     actions: read           # kun strengt nødvendig for private repoer (CodeQL leser workflow-run status)
 on:
   workflow_call:
+    secrets:
+      SONAR_TOKEN:
+        description: "Token for autentisering mot SonarQube Cloud. Kreves når `sonar: true` (default)."
+        required: false
     inputs:
       java-version:
         required: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,6 +53,22 @@ jobs:
       contents: read
       security-events: write
     steps:
+      - name: Sjekk påkrevde secrets
+        if: inputs.language == 'java'
+        env:
+          SONAR: ${{ inputs.sonar }}
+          USE_READER: ${{ inputs.use-reader }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          READER_TOKEN: ${{ secrets.READER_TOKEN }}
+        run: |
+          if [[ "$SONAR" == "true" && -z "$SONAR_TOKEN" ]]; then
+            echo "::error::SONAR_TOKEN må være satt når sonar: true. Legg til secreten i kallende repo (eller sett sonar: false)."
+            exit 1
+          fi
+          if [[ "$USE_READER" == "true" && -z "$READER_TOKEN" ]]; then
+            echo "::error::READER_TOKEN må være satt når use-reader: true. Send inn secreten fra kallende workflow (eller sett use-reader: false)."
+            exit 1
+          fi
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
         with:
           fetch-depth: 0 # full historikk trengs for korrekt Sonar blame/nykode-analyse (og tilgjengeliggjør tags)


### PR DESCRIPTION
## Hva

1. **Deklarerer `SONAR_TOKEN`** som en eksplisitt `workflow_call.secrets`-input i `codeql.yml`:

```yaml
    secrets:
      SONAR_TOKEN:
        description: "Token for autentisering mot SonarQube Cloud. Kreves når `sonar: true` (default)."
        required: false
```

2. **Tidlig preflight-sjekk** av påkrevde secrets som første steg i jobben. Feiler raskt med tydelig `::error::`-melding i stedet for langt uti bygget:
   - `sonar: true` uten `SONAR_TOKEN` → feiler
   - `use-reader: true` uten `READER_TOKEN` → feiler

```yaml
      - name: Sjekk påkrevde secrets
        if: inputs.language == 'java'
        env:
          SONAR: ${{ inputs.sonar }}
          USE_READER: ${{ inputs.use-reader }}
          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
          READER_TOKEN: ${{ secrets.READER_TOKEN }}
        run: |
          if [[ "$SONAR" == "true" && -z "$SONAR_TOKEN" ]]; then
            echo "::error::SONAR_TOKEN må være satt når sonar: true ..."
            exit 1
          fi
          if [[ "$USE_READER" == "true" && -z "$READER_TOKEN" ]]; then
            echo "::error::READER_TOKEN må være satt når use-reader: true ..."
            exit 1
          fi
```

## Hvorfor

- `codeql.yml` bruker `secrets.SONAR_TOKEN` i Sonar-steget, men den var ikke deklarert. Eksplisitt deklarasjon dokumenterer kravet.
- Uten preflight-sjekk feilet manglende `SONAR_TOKEN` først i Sonar-steget med en kryptisk "Not authorized"-melding etter et helt Maven-bygg. Nå feiler det umiddelbart med en tydelig forklaring.
- Secrets kan ikke brukes i `if:`, så de sendes via `env:` og sjekkes med tom-test (`-z`) i bash.
- Gated på `inputs.language == 'java'`, siden både `sonar` og `use-reader` kun er relevante for Java-bygg.

Relatert: SONAR_TOKEN ble lagt til i fp-sak (fp-sak#7311).

## Bakoverkompatibilitet

Ikke-brytende. `SONAR_TOKEN` er `required: false`, så callers som bruker `secrets: inherit` fungerer som før. Preflight-sjekken feiler kun når en påkrevd secret faktisk mangler for den valgte konfigurasjonen.