### PR TITLE
TFP-6363: fjern READER_TOKEN fra mvn-dependency-submission

### DIFF
--- a/.github/workflows/mvn-dependency-submission.yml
+++ b/.github/workflows/mvn-dependency-submission.yml
@@ -12,7 +12,7 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ (github.actor != 'dependabot[bot]' && secrets.READER_TOKEN) || secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_ACTOR: ${{ github.actor }}
     permissions:
       contents: write   # submitte dependency snapshot via Dependency Submission API


### PR DESCRIPTION
## Hva
Fjerner den gjenværende `READER_TOKEN`-referansen i `mvn-dependency-submission.yml` og bruker `GITHUB_TOKEN` direkte.

## Hvorfor det er trygt
- Avhengighetene er offentlige @navikt-pakker som resolves uten GitHub Packages-auth (bevist ved at `build-feature`-konsumenter bygger grønt med `packages: none`).
- Jobben trenger kun `contents: write` (submitte dependency-snapshot via Dependency Submission API) — den leser ingen pakker som krever `packages`-scope.
- **Alle 33 konsumentene** gir allerede nøyaktig `permissions: { contents: write }`, så ingen konsument brekker. De som fortsatt har `secrets: inherit` påvirkes ikke (READER_TOKEN var uansett tom → falt til GITHUB_TOKEN).

## Del av TFP-6363
Steg mot å fjerne all READER_TOKEN-bruk. Gjenstår etter denne: `build-feature.yml`, `build-app-no-db.yml` (use-reader-ternær) og `dependabot.yml` (dependabot-secret).