### PR TITLE
TFP-6363: fjern use-reader/READER_TOKEN og fiks template-injection

### DIFF
--- a/.github/actions/build-maven-application/action.yml
+++ b/.github/actions/build-maven-application/action.yml
@@ -41,3 +41,5 @@ runs:
         BUILD_VERSION: ${{ steps.generate-build-version.outputs.build-version }}
         T_2C: ${{ inputs.t-2c }}
         PROFIL: ${{ inputs.profil }}
+        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_ACTOR: ${{ github.actor }}

--- a/.github/actions/build-maven-application/action.yml
+++ b/.github/actions/build-maven-application/action.yml
@@ -20,14 +20,21 @@ runs:
       id: generate-build-version
       shell: bash
       run: echo "build-version=$(date +%Y.%m.%d.%H%M%S)-$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_OUTPUT
+
     - name: Print build version
       shell: bash
-      run: echo "Generated build-version is ${{ steps.generate-build-version.outputs.build-version }}"
+      env:
+        BUILD_VERSION: ${{ steps.generate-build-version.outputs.build-version }}
+      run: echo "Generated build-version is $BUILD_VERSION"
+
     - name: Build artifacts
       shell: bash
       run: |
-        echo "Building artifacts ${{ steps.generate-build-version.outputs.build-version }}"
-        mvn versions:set -DnewVersion="${{ steps.generate-build-version.outputs.build-version }}" -q -e -B
-        mvn install ${{ inputs.t-2c }} -ntp -e -B ${{ inputs.profil }} ${{ (inputs.skip-tests == 'true' && '-DskipTests') || '' }}
+        echo "Building artifacts $BUILD_VERSION"
+        mvn versions:set -DnewVersion="$BUILD_VERSION" -q -e -B
+        mvn install $T_2C -ntp -e -B $PROFIL ${{ (inputs.skip-tests == 'true' && '-DskipTests') || '' }}
       env:
         TESTCONTAINERS_REUSE_ENABLE: true
+        BUILD_VERSION: ${{ steps.generate-build-version.outputs.build-version }}
+        T_2C: ${{ inputs.t-2c }}
+        PROFIL: ${{ inputs.profil }}

--- a/.github/actions/build-maven-application/action.yml
+++ b/.github/actions/build-maven-application/action.yml
@@ -1,18 +1,21 @@
-name: 'Maven install'
-description: 'Maven install'
+name: "Maven install"
+description: "Maven install"
+
 inputs:
   t-2c:
-    description: 'Thread config to use'
+    description: "Thread config to use"
     required: false
-    default: ''
+    default: ""
   profil:
-    description: 'Maven profile to use (f.eks. sonar spesifisers -Psonar'
+    description: "Maven profile to use (f.eks. sonar spesifisers -Psonar"
     required: false
-    default: ''
+    default: ""
+
 outputs:
   build-version:
     description: "Build version"
     value: ${{ steps.generate-build-version.outputs.build-version }}
+
 runs:
   using: "composite"
   steps:

--- a/.github/actions/build-push-docker-image/action.yml
+++ b/.github/actions/build-push-docker-image/action.yml
@@ -36,23 +36,30 @@ runs:
   steps:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # ratchet:docker/setup-qemu-action@v4.2.0
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # ratchet:docker/setup-buildx-action@v4.3.0
+
     - name: NAIS login
       uses: nais/login@40b72a35a18ddf2ad74b632461139ab838cc2a2f # ratchet:nais/login@v0
       id: login
       with:
         team: ${{ inputs.namespace }}
+
     - name: Setup environment
       shell: bash
+      env:
+        DOCKERFILE: ${{ inputs.dockerfile }}
+        DOCKER_CONTEXT: ${{ inputs.docker_context }}
       run: |
-        if [ ! -f "${{ inputs.dockerfile }}" ]; then
-          echo "::error ::Dockerfile not found: ${{ inputs.dockerfile }}. Do you need to prepend context or working directory?"
+        if [ ! -f "$DOCKERFILE" ]; then
+          echo "::error ::Dockerfile not found: $DOCKERFILE. Do you need to prepend context or working directory?"
           exit 1
-        elif [ ! -d "${{ inputs.docker_context }}" ]; then
-          echo "::error ::Docker context not found: ${{ inputs.docker_context }}."
+        elif [ ! -d "$DOCKER_CONTEXT" ]; then
+          echo "::error ::Docker context not found: $DOCKER_CONTEXT."
           exit 1
         fi
+
     - name: Docker meta
       uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # ratchet:docker/metadata-action@v6.2.0
       id: meta
@@ -62,6 +69,7 @@ runs:
           type=raw,value=${{ inputs.build-version }}
           # set latest tag for default branch (master)
           type=raw,value=latest,enable={{is_default_branch}}
+
     - name: Bygg og push docker image
       uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # ratchet:docker/build-push-action@v7.3.0
       id: build_push

--- a/.github/actions/build-push-docker-image/action.yml
+++ b/.github/actions/build-push-docker-image/action.yml
@@ -1,5 +1,6 @@
 name: "Build and push docker image"
 description: "Build and push docker image"
+
 inputs:
   build-version:
     description: "Image tag for the docker image"
@@ -31,6 +32,7 @@ inputs:
   build_args:
     description: "List of build-time variables"
     required: false
+
 runs:
   using: "composite"
   steps:

--- a/.github/actions/knip-it/action.yml
+++ b/.github/actions/knip-it/action.yml
@@ -20,6 +20,8 @@ runs:
   using: composite
   steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
+      with:
+        persist-credentials: false
 
     - uses: navikt/fp-gha-workflows/.github/actions/setup-yarnrc@main # ratchet:exclude
       if: inputs.package-manager == 'yarn'

--- a/.github/actions/knip-it/action.yml
+++ b/.github/actions/knip-it/action.yml
@@ -33,8 +33,8 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ inputs.package-manager }}
-        registry-url: 'https://npm.pkg.github.com'
-        scope: '@navikt'
+        registry-url: "https://npm.pkg.github.com"
+        scope: "@navikt"
 
     - name: Yarn install
       if: inputs.package-manager == 'yarn'

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,17 +10,20 @@ Reusable GitHub workflows and composite actions for Team Foreldrepenger reposito
 Only repo-specific deltas belong here.
 
 ## Scope
+
 - Reusable workflows and composite actions for most Team Foreldrepenger repos.
 - Notable repos with independent CI setups: `fp-autotest`, `fp-iac`, `fp-baseimages`.
 - Changes here fan out broadly. Keep inputs backward-compatible and flag breaking changes clearly in PRs.
 
 ## Layout
+
 - `.github/workflows/` — `workflow_call` workflows (`build-*`, `release-*`, `deploy*`, `codeql`, ...)
 - `.github/actions/` — composite actions
 - `.github/codeql/` — shared CodeQL config
 - `.github/dependabot.yml` - local dependabot configuration
 
 ## Conventions
+
 - Version pinning as of `fp-context/operations/ci-cd.md#workflow-pinning--ratchet-policy`
 - Use explicit `permissions:` with least privilege
 - Composite steps use `shell: bash` and quoted variables
@@ -29,4 +32,5 @@ Only repo-specific deltas belong here.
 - Default version bumps for Java, Node, or runner images fan out to consumers on their next run
 
 ## Catalog
+
 Reusable workflows and composite actions are cataloged in `README.md`.

--- a/.github/workflows/build-app-no-db.yml
+++ b/.github/workflows/build-app-no-db.yml
@@ -28,11 +28,6 @@ on:
         type: boolean
         description: Skal docker image pushes?
         default: false
-      use-reader:
-        required: false
-        type: boolean
-        description: Hvilket token skal brukes?
-        default: false
       namespace:
         required: false
         type: string
@@ -70,7 +65,7 @@ jobs:
         with:
           t-2c: ${{ inputs.t-2c }}
         env:
-          GITHUB_TOKEN: ${{ (github.actor != 'dependabot[bot]' && inputs.use-reader && secrets.READER_TOKEN) || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
       - name: Bygg og push docker image
         if: inputs.build-image

--- a/.github/workflows/build-app-no-db.yml
+++ b/.github/workflows/build-app-no-db.yml
@@ -53,12 +53,15 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
         with:
           fetch-depth: 0 # checkout gir shallow copy - fetch-depth: 0 vil tilgjengeliggjøre tags
+          persist-credentials: false
+
       - name: Set up JDK-${{ inputs.java-version }} with cache
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # ratchet:actions/setup-java@v5.7.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: 'temurin'
           cache: 'maven'
+
       - name: Maven install and test
         id: build-and-test
         uses: navikt/fp-gha-workflows/.github/actions/build-maven-application@main # ratchet:exclude
@@ -67,6 +70,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
+
       - name: Bygg og push docker image
         if: inputs.build-image
         uses: navikt/fp-gha-workflows/.github/actions/build-push-docker-image@main # ratchet:exclude
@@ -74,6 +78,7 @@ jobs:
           build-version: ${{ steps.build-and-test.outputs.build-version }}
           push-image: ${{ inputs.push-image }}
           namespace: ${{ inputs.namespace }}
+
       - name: Clean up generated stuff before caching
         shell: bash
         run: |

--- a/.github/workflows/build-app-no-db.yml
+++ b/.github/workflows/build-app-no-db.yml
@@ -67,9 +67,6 @@ jobs:
         uses: navikt/fp-gha-workflows/.github/actions/build-maven-application@main # ratchet:exclude
         with:
           t-2c: ${{ inputs.t-2c }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_ACTOR: ${{ github.actor }}
 
       - name: Bygg og push docker image
         if: inputs.build-image

--- a/.github/workflows/build-app-no-db.yml
+++ b/.github/workflows/build-app-no-db.yml
@@ -7,17 +7,17 @@ on:
         required: false
         type: string
         description: Miljø versjon som skal brukes til bygg.
-        default: 'ubuntu-latest'
+        default: "ubuntu-latest"
       t-2c:
         required: false
         type: string
         description: Tråd konfig til maven.
-        default: ''
+        default: ""
       java-version:
         required: false
         type: string
         description: Java SDK versjon som skal brukes.
-        default: '25'
+        default: "25"
       build-image:
         required: false
         type: boolean
@@ -31,8 +31,8 @@ on:
       namespace:
         required: false
         type: string
-        description: 'The namespace to push images to'
-        default: 'teamforeldrepenger'
+        description: "The namespace to push images to"
+        default: "teamforeldrepenger"
     outputs:
       build-version:
         description: "Build version"
@@ -59,8 +59,8 @@ jobs:
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # ratchet:actions/setup-java@v5.7.0
         with:
           java-version: ${{ inputs.java-version }}
-          distribution: 'temurin'
-          cache: 'maven'
+          distribution: "temurin"
+          cache: "maven"
 
       - name: Maven install and test
         id: build-and-test

--- a/.github/workflows/build-feature.yml
+++ b/.github/workflows/build-feature.yml
@@ -35,12 +35,15 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
         with:
           fetch-depth: 0 # checkout gir shallow copy - fetch-depth: 0 vil tilgjengeliggjøre tags
+          persist-credentials: false
+
       - name: Set up JDK-${{ inputs.java-version }} with cache
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # ratchet:actions/setup-java@v5.7.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: 'temurin'
           cache: 'maven'
+
       - name: Maven verify
         shell: bash
         working-directory: ${{ inputs.working-directory }}
@@ -49,6 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
           T_2C: ${{ inputs.t-2c }}
+
       - name: Clean up generated stuff before caching
         run: |
           if [[ -d "~/.m2/repository/no/nav/foreldrepenger" ]]; then

--- a/.github/workflows/build-feature.yml
+++ b/.github/workflows/build-feature.yml
@@ -18,11 +18,6 @@ on:
         type: string
         description: Java SDK versjon som skal brukes.
         default: '25'
-      use-reader:
-        required: false
-        type: boolean
-        description: Hvilket token skal brukes?
-        default: false
       working-directory:
         required: false
         default: .
@@ -49,10 +44,11 @@ jobs:
       - name: Maven verify
         shell: bash
         working-directory: ${{ inputs.working-directory }}
-        run: mvn verify -ntp -e -B ${{ inputs.t-2c }}
+        run: mvn verify -ntp -e -B ${T_2C}
         env:
-          GITHUB_TOKEN: ${{ (github.actor != 'dependabot[bot]' && inputs.use-reader && secrets.READER_TOKEN) || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
+          T_2C: ${{ inputs.t-2c }}
       - name: Clean up generated stuff before caching
         run: |
           if [[ -d "~/.m2/repository/no/nav/foreldrepenger" ]]; then

--- a/.github/workflows/build-feature.yml
+++ b/.github/workflows/build-feature.yml
@@ -7,17 +7,17 @@ on:
         required: false
         type: string
         description: Miljø versjon som skal brukes til bygg.
-        default: 'ubuntu-latest'
+        default: "ubuntu-latest"
       t-2c:
         required: false
         type: string
         description: Tråd konfig til maven.
-        default: ''
+        default: ""
       java-version:
         required: false
         type: string
         description: Java SDK versjon som skal brukes.
-        default: '25'
+        default: "25"
       working-directory:
         required: false
         default: .
@@ -41,8 +41,8 @@ jobs:
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # ratchet:actions/setup-java@v5.7.0
         with:
           java-version: ${{ inputs.java-version }}
-          distribution: 'temurin'
-          cache: 'maven'
+          distribution: "temurin"
+          cache: "maven"
 
       - name: Maven verify
         shell: bash

--- a/.github/workflows/cdn-upload.yml
+++ b/.github/workflows/cdn-upload.yml
@@ -35,6 +35,7 @@ jobs:
         id: login
         with:
           team: teamforeldrepenger
+
       - name: Extract assets from built image
         env:
           IMAGE: ${{ steps.login.outputs.registry }}/${{ github.repository }}${{ inputs.image_suffix }}:${{ inputs.image }}
@@ -44,6 +45,7 @@ jobs:
           cid=$(docker create "$IMAGE")
           docker cp "$cid:$IMAGE_PATH" ./cdn-dist
           docker rm "$cid"
+
       - name: Upload static files to CDN
         id: upload
         uses: nais/deploy/actions/cdn-upload/v2@849e900e3cfa7faf7ad1532bb3a3e6499c932199 # ratchet:nais/deploy/actions/cdn-upload/v2@v2
@@ -52,6 +54,7 @@ jobs:
           source: ./cdn-dist
           source_keep_parent_name: false
           destination: ${{ inputs.destination }}
+
       - run: 'echo "uploaded file $UPLOADED"'
         env:
           UPLOADED: ${{ steps.upload.outputs.uploaded }}

--- a/.github/workflows/cdn-upload.yml
+++ b/.github/workflows/cdn-upload.yml
@@ -38,10 +38,11 @@ jobs:
       - name: Extract assets from built image
         env:
           IMAGE: ${{ steps.login.outputs.registry }}/${{ github.repository }}${{ inputs.image_suffix }}:${{ inputs.image }}
+          IMAGE_PATH: ${{ inputs.image_path }}
         run: |
           docker pull "$IMAGE"
           cid=$(docker create "$IMAGE")
-          docker cp "$cid:${{ inputs.image_path }}" ./cdn-dist
+          docker cp "$cid:$IMAGE_PATH" ./cdn-dist
           docker rm "$cid"
       - name: Upload static files to CDN
         id: upload
@@ -51,4 +52,6 @@ jobs:
           source: ./cdn-dist
           source_keep_parent_name: false
           destination: ${{ inputs.destination }}
-      - run: 'echo "uploaded file ${{ steps.upload.outputs.uploaded }}"'
+      - run: 'echo "uploaded file $UPLOADED"'
+        env:
+          UPLOADED: ${{ steps.upload.outputs.uploaded }}

--- a/.github/workflows/cdn-upload.yml
+++ b/.github/workflows/cdn-upload.yml
@@ -8,20 +8,20 @@ on:
       image:
         required: true
         type: string
-        description: 'Image tag (build-version) å hente assets fra (eksempel 2023.03.10.080433-f821119)'
+        description: "Image tag (build-version) å hente assets fra (eksempel 2023.03.10.080433-f821119)"
       image_suffix:
         required: true
         type: string
-        description: 'Suffix på imaget som assets hentes fra (eksempel /engangsstonad)'
+        description: "Suffix på imaget som assets hentes fra (eksempel /engangsstonad)"
       destination:
         required: true
         type: string
-        description: 'CDN-destinasjon, typisk appens vite base (eksempel /engangsstonad/soknad)'
+        description: "CDN-destinasjon, typisk appens vite base (eksempel /engangsstonad/soknad)"
       image_path:
         required: false
         type: string
-        description: 'Sti til de bygde assetene inne i containeren'
-        default: '/app/public'
+        description: "Sti til de bygde assetene inne i containeren"
+        default: "/app/public"
 
 jobs:
   upload-to-cdn:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,9 +61,6 @@ jobs:
         with:
           t-2c: ${{ inputs.t-2c }}
           profil: -Psonar
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_ACTOR: ${{ github.actor }}
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # ratchet:github/codeql-action/analyze@v4.37.7

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,15 +46,15 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # ratchet:github/codeql-action/init@v4.37.7
         with:
-          languages: 'java'
+          languages: "java"
           config-file: navikt/fp-gha-workflows/.github/codeql/codeql-config.yml@main # ratchet:exclude
 
       - name: Set up JDK-${{ inputs.java-version }} with cache
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # ratchet:actions/setup-java@v5.7.0
         with:
           java-version: ${{ inputs.java-version }}
-          distribution: 'temurin'
-          cache: 'maven'
+          distribution: "temurin"
+          cache: "maven"
 
       - name: Maven install and test
         uses: navikt/fp-gha-workflows/.github/actions/build-maven-application@main # ratchet:exclude

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,11 +12,6 @@ on:
         type: string
         description: Java SDK versjon som skal brukes.
         default: "25"
-      language:
-        required: false
-        type: string
-        description: Språk som skal scannes
-        default: "java"
       sonar:
         required: false
         type: boolean
@@ -43,33 +38,25 @@ jobs:
       contents: read          # checkout av koden
       security-events: write  # laste opp CodeQL/SARIF-resultater til Code scanning
     steps:
-      - name: Sjekk påkrevde secrets
-        if: inputs.language == 'java'
-        env:
-          SONAR: ${{ inputs.sonar }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: |
-          if [[ "$SONAR" == "true" && -z "$SONAR_TOKEN" ]]; then
-            echo "::error::SONAR_TOKEN må være satt når sonar: true. Legg til secreten i kallende repo (eller sett sonar: false)."
-            exit 1
-          fi
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
         with:
           fetch-depth: 0 # full historikk trengs for korrekt Sonar blame/nykode-analyse (og tilgjengeliggjør tags)
+          persist-credentials: false
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # ratchet:github/codeql-action/init@v4.37.7
         with:
-          languages: ${{ inputs.language }}
+          languages: 'java'
           config-file: navikt/fp-gha-workflows/.github/codeql/codeql-config.yml@main # ratchet:exclude
+
       - name: Set up JDK-${{ inputs.java-version }} with cache
-        if: inputs.language == 'java'
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # ratchet:actions/setup-java@v5.7.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: 'temurin'
           cache: 'maven'
+
       - name: Maven install and test
-        if: inputs.language == 'java'
         uses: navikt/fp-gha-workflows/.github/actions/build-maven-application@main # ratchet:exclude
         with:
           t-2c: ${{ inputs.t-2c }}
@@ -77,15 +64,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
-      - name: Autobuild
-        if: inputs.language != 'java'
-        uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # ratchet:github/codeql-action/autobuild@v4.37.7
+
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # ratchet:github/codeql-action/analyze@v4.37.7
         with:
-          category: "/language:${{ inputs.language }}"
+          category: "/language:java"
+
       - name: Perform Sonar Analysis
-        if: inputs.language == 'java' && inputs.sonar
+        if: inputs.sonar
         run: |
           mvn jacoco:report jacoco:report-aggregate sonar:sonar ${T_2C} -e -q -B -Djacoco.destFile=$(pwd)/target/jacoco.exec -Psonar
         env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,11 +17,6 @@ on:
         type: string
         description: Språk som skal scannes
         default: "java"
-      use-reader:
-        required: false
-        type: boolean
-        description: Utfaset/ignorert – bygg bruker alltid GITHUB_TOKEN.
-        default: false
       sonar:
         required: false
         type: boolean

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,5 +1,5 @@
-name: Deploy storybook
-# Autentiserer mot npm.pkg.github.com med den innebygde GITHUB_TOKEN.
+name: Deploy storybook til GitHub Pages
+# Gjenbrukbar workflow: bygger og deployerer Storybook til GitHub Pages.
 on:
   workflow_call:
     inputs:
@@ -30,10 +30,10 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      # Trinn 1: Sjekk ut repository
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
-      # Trinn 2 Sett opp yarn/pnpm + node
       - uses: navikt/fp-gha-workflows/.github/actions/setup-yarnrc@main # ratchet:exclude
         if: inputs.package-manager == 'yarn'
 
@@ -47,7 +47,6 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           scope: '@navikt'
 
-      # Trinn 3: Håndter caching for turbo builds
       - name: Cache turbo build setup
         if: inputs.cache == 'turbo'
         id: hent-cache
@@ -58,27 +57,26 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-
 
-      # Trinn 4: yarn install+build
       - name: Installer avhengigheter med Yarn
         if: inputs.package-manager == 'yarn'
         run: |
           yarn install --immutable
+
       - name: Bygg Storybook med Yarn
         if: inputs.package-manager == 'yarn'
         run: yarn build:storybook
 
-      # Trinn 4: pnpm install+build
       - name: Installer avhengigheter med Pnpm
         if: inputs.package-manager == 'pnpm'
         run: |
           pnpm install --frozen-lockfile --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Bygg Storybook med Pnpm
         if: inputs.package-manager == 'pnpm'
         run: pnpm build:storybook
 
-      # Trinn 5: Konfigurer og deploy til GitHub Pages
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # ratchet:actions/configure-pages@v6.0.0
 
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # ratchet:actions/upload-pages-artifact@v5.0.0
@@ -88,7 +86,6 @@ jobs:
       - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # ratchet:actions/deploy-pages@v5.0.0
         id: deployment
 
-      # Trinn 6: Lagre turbo cache
       - name: Lagre turbo cache
         if: always() && inputs.cache == 'turbo' && steps.hent-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # ratchet:actions/cache/save@v6.1.0

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -44,8 +44,8 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
           cache: ${{ inputs.package-manager }}
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@navikt'
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@navikt"
 
       - name: Cache turbo build setup
         if: inputs.cache == 'turbo'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,6 +68,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
         with:
           ref: ${{ (inputs.branch != '' && inputs.branch) || '' }}
+          persist-credentials: false
 
       - name: Deploy ${{ inputs.cluster }} fra Github
         if: inputs.gar == 'false'

--- a/.github/workflows/mvn-dependency-submission.yml
+++ b/.github/workflows/mvn-dependency-submission.yml
@@ -8,12 +8,10 @@ on:
         type: string
         description: Java SDK versjon som skal brukes.
         default: "25"
+
 jobs:
   scan:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GITHUB_ACTOR: ${{ github.actor }}
     permissions:
       contents: write   # submitte dependency snapshot via Dependency Submission API
     steps:
@@ -39,10 +37,12 @@ jobs:
           BUILD_VERSION: ${{ steps.generate-build-version.outputs.build-version }}
         run: echo "Generated build-version is $BUILD_VERSION"
 
-      - name: Build artifactsM
+      - name: Build artifacts
         shell: bash
         env:
           BUILD_VERSION: ${{ steps.generate-build-version.outputs.build-version }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_ACTOR: ${{ github.actor }}
         run: |
           echo "Building artifacts $BUILD_VERSION"
           mvn versions:set -DnewVersion="$BUILD_VERSION" -q -e -B
@@ -51,3 +51,6 @@ jobs:
         uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8 # ratchet:advanced-security/maven-dependency-submission-action@v5.0.0
         with:
           maven-args: -DskipTests
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_ACTOR: ${{ github.actor }}

--- a/.github/workflows/mvn-dependency-submission.yml
+++ b/.github/workflows/mvn-dependency-submission.yml
@@ -30,12 +30,16 @@ jobs:
         run: echo "build-version=$(date +%Y.%m.%d.%H%M%S)-$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_OUTPUT
       - name: Print build version
         shell: bash
-        run: echo "Generated build-version is ${{ steps.generate-build-version.outputs.build-version }}"
+        env:
+          BUILD_VERSION: ${{ steps.generate-build-version.outputs.build-version }}
+        run: echo "Generated build-version is $BUILD_VERSION"
       - name: Build artifactsM
         shell: bash
+        env:
+          BUILD_VERSION: ${{ steps.generate-build-version.outputs.build-version }}
         run: |
-          echo "Building artifacts ${{ steps.generate-build-version.outputs.build-version }}"
-          mvn versions:set -DnewVersion="${{ steps.generate-build-version.outputs.build-version }}" -q -e -B
+          echo "Building artifacts $BUILD_VERSION"
+          mvn versions:set -DnewVersion="$BUILD_VERSION" -q -e -B
       - name: Submit Dependency Snapshot to Github Security
         uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8 # ratchet:advanced-security/maven-dependency-submission-action@v5.0.0
         with:

--- a/.github/workflows/mvn-dependency-submission.yml
+++ b/.github/workflows/mvn-dependency-submission.yml
@@ -18,21 +18,27 @@ jobs:
       contents: write   # submitte dependency snapshot via Dependency Submission API
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+
       - name: Set up JDK-${{ inputs.java-version }} with cache
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # ratchet:actions/setup-java@v5.7.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: 'temurin'
           cache: 'maven'
+
       - name: Generate build version
         id: generate-build-version
         shell: bash
         run: echo "build-version=$(date +%Y.%m.%d.%H%M%S)-$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_OUTPUT
+
       - name: Print build version
         shell: bash
         env:
           BUILD_VERSION: ${{ steps.generate-build-version.outputs.build-version }}
         run: echo "Generated build-version is $BUILD_VERSION"
+
       - name: Build artifactsM
         shell: bash
         env:
@@ -40,6 +46,7 @@ jobs:
         run: |
           echo "Building artifacts $BUILD_VERSION"
           mvn versions:set -DnewVersion="$BUILD_VERSION" -q -e -B
+
       - name: Submit Dependency Snapshot to Github Security
         uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8 # ratchet:advanced-security/maven-dependency-submission-action@v5.0.0
         with:

--- a/.github/workflows/mvn-dependency-submission.yml
+++ b/.github/workflows/mvn-dependency-submission.yml
@@ -7,7 +7,7 @@ on:
         required: false
         type: string
         description: Java SDK versjon som skal brukes.
-        default: '25'
+        default: "25"
 jobs:
   scan:
     runs-on: ubuntu-latest
@@ -25,8 +25,8 @@ jobs:
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # ratchet:actions/setup-java@v5.7.0
         with:
           java-version: ${{ inputs.java-version }}
-          distribution: 'temurin'
-          cache: 'maven'
+          distribution: "temurin"
+          cache: "maven"
 
       - name: Generate build version
         id: generate-build-version

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,6 +2,7 @@ name: Release draft update
 # Gjenbrukbar workflow: oppdaterer utkast til release notes med release-drafter.
 on:
   workflow_call:
+
 jobs:
   update_release_draft:
     name: Release draft

--- a/.github/workflows/release-feature.yml
+++ b/.github/workflows/release-feature.yml
@@ -49,12 +49,15 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.release-branch }}
+          persist-credentials: false
+
       - name: Set up JDK-${{ inputs.java-version }} with cache
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # ratchet:actions/setup-java@v5.7.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: 'temurin'
           cache: 'maven'
+
       - name: Publish artifacts
         working-directory: ${{ inputs.working-directory }}
         run: |

--- a/.github/workflows/release-feature.yml
+++ b/.github/workflows/release-feature.yml
@@ -6,32 +6,32 @@ on:
       release-version:
         required: true
         type: string
-        description: 'The release version.'
+        description: "The release version."
       java-version:
         required: false
         type: string
-        description: 'Java SDK versjon som skal brukes.'
-        default: '25'
+        description: "Java SDK versjon som skal brukes."
+        default: "25"
       mvn-projects:
         required: false
         type: string
-        description: 'Comma-delimited list of specified reactor projects to build instead of all projects.'
-        default: ''
+        description: "Comma-delimited list of specified reactor projects to build instead of all projects."
+        default: ""
       release-profiles:
         required: false
         type: string
-        description: 'Profiles which should be used when releasing an artifact.'
-        default: '-Pdeploy'
+        description: "Profiles which should be used when releasing an artifact."
+        default: "-Pdeploy"
       release-branch:
         required: false
         type: string
-        description: 'Hvilken branch skal releases. Default master.'
-        default: 'master'
+        description: "Hvilken branch skal releases. Default master."
+        default: "master"
       release-file:
         required: false
         type: string
-        description: 'Hvilken pom.xml fil skal releases. Default empty.'
-        default: ''
+        description: "Hvilken pom.xml fil skal releases. Default empty."
+        default: ""
       working-directory:
         required: false
         default: .
@@ -55,8 +55,8 @@ jobs:
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # ratchet:actions/setup-java@v5.7.0
         with:
           java-version: ${{ inputs.java-version }}
-          distribution: 'temurin'
-          cache: 'maven'
+          distribution: "temurin"
+          cache: "maven"
 
       - name: Publish artifacts
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/release-feature.yml
+++ b/.github/workflows/release-feature.yml
@@ -58,8 +58,12 @@ jobs:
       - name: Publish artifacts
         working-directory: ${{ inputs.working-directory }}
         run: |
-          mvn -B versions:set -DnewVersion=${{ inputs.release-version }} ${{ inputs.release-file }}
-          mvn -B -Dmaven.wagon.http.pool=false -DskipTests clean deploy ${{ inputs.mvn-projects }} ${{ inputs.release-profiles }} ${{ inputs.release-file }}
+          mvn -B versions:set -DnewVersion="$RELEASE_VERSION" $RELEASE_FILE
+          mvn -B -Dmaven.wagon.http.pool=false -DskipTests clean deploy $MVN_PROJECTS $RELEASE_PROFILES $RELEASE_FILE
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
+          RELEASE_VERSION: ${{ inputs.release-version }}
+          RELEASE_FILE: ${{ inputs.release-file }}
+          MVN_PROJECTS: ${{ inputs.mvn-projects }}
+          RELEASE_PROFILES: ${{ inputs.release-profiles }}

--- a/README.md
+++ b/README.md
@@ -14,27 +14,35 @@ and applies to every workflow in every fp-repo.
 
 Triggered via `workflow_call`.
 
-| Workflow | Purpose | Key inputs |
-|----------|---------|------------|
-| `build-app-no-db.yml` | Maven build + optional Docker image build/push, no DB | `java-version`, `build-image`, `push-image`, `namespace` |
-| `build-feature.yml` | Build feature branch (no deploy) | `java-version`, `t-2c`, `working-directory` |
-| `codeql.yml` | CodeQL static analysis (+ optional Sonar) | `language`, `sonar`, `java-version` |
-| `deploy.yml` | Deploy image to a NAIS cluster | `image` (req), `cluster` (req), `namespace`, `naiserator_file`, `gar` |
-| `deploy-storybook.yml` | Build + deploy Storybook to GitHub Pages | `package-manager` (req), `cache` (req) |
-| `mvn-dependency-submission.yml` | Submit Maven dep graph to GitHub Dependency Submission API | `java-version` |
-| `release-drafter.yml` | Auto-draft release notes | — |
-| `release-feature.yml` | Release artifact from a feature branch | `release-version` (req), `release-branch`, `release-profiles` |
+| Workflow | Purpose | Key inputs | Secrets |
+|----------|---------|------------|---------|
+| `build-app-no-db.yml` | Maven build + optional Docker image build/push, no DB | `java-version`, `build-image`, `push-image`, `namespace` | — |
+| `build-feature.yml` | Build feature branch (no deploy) | `java-version`, `t-2c`, `working-directory` | — |
+| `codeql.yml` | CodeQL static analysis (+ optional Sonar) | `sonar`, `java-version`, `t-2c` | `SONAR_TOKEN` (optional, brukes når `sonar: true`) |
+| `deploy.yml` | Deploy image to a NAIS cluster | `image` (req), `cluster` (req), `namespace`, `naiserator_file`, `gar` | — |
+| `deploy-storybook.yml` | Build + deploy Storybook to GitHub Pages | `package-manager` (req), `cache` (req) | — |
+| `mvn-dependency-submission.yml` | Submit Maven dep graph to GitHub Dependency Submission API | `java-version` | — |
+| `release-drafter.yml` | Auto-draft release notes | — | — |
+| `release-feature.yml` | Release artifact from a feature branch | `release-version` (req), `release-branch`, `release-profiles` | — |
+
+Alle workflowene bruker det innebygde `GITHUB_TOKEN` automatisk (via
+`permissions:`) — de trenger ikke eksplisitt tilsendte secrets utover det som
+står i tabellen. Send kun de secretsene som faktisk er deklarert; unngå
+`secrets: inherit`.
 
 ## Composite actions (`.github/actions/`)
 
 Reusable steps for use inside any workflow.
 
-| Action | Purpose | Key inputs |
-|--------|---------|------------|
-| `build-maven-application` | Maven install with cache + build-version output | `t-2c`, `profil` |
-| `build-push-docker-image` | Build + push a Docker image | `build-version` (req), `dockerfile`, `push-image` |
-| `knip-it` | Frontend unused-export detection (Knip) | `package-manager` (req) |
-| `setup-yarnrc` | Yarn registry config for `@navikt/*` packages | — |
+| Action | Purpose | Key inputs | Secrets |
+|--------|---------|------------|---------|
+| `build-maven-application` | Maven install with cache + build-version output | `t-2c`, `profil` | — |
+| `build-push-docker-image` | Build + push a Docker image | `build-version` (req), `dockerfile` (req), `push-image`, `docker_context` | — |
+| `knip-it` | Frontend unused-export detection (Knip) | `package-manager` (req), `node-version` | — |
+| `setup-yarnrc` | Yarn registry config for `@navikt/*` packages | — | — |
+
+Composite actions deklarerer ikke egne secrets — de arver `GITHUB_TOKEN` og
+miljøet fra jobben som kaller dem.
 
 ## Shared config
 
@@ -53,8 +61,10 @@ jobs:
     with:
       build-image: true
       push-image: true
-    secrets: inherit
 ```
+
+Send secrets eksplisitt kun når en workflow deklarerer dem (f.eks. `SONAR_TOKEN`
+til `codeql.yml`) — ikke bruk `secrets: inherit`.
 
 Reference composite actions the same way:
 

--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@ and applies to every workflow in every fp-repo.
 
 Triggered via `workflow_call`.
 
-| Workflow | Purpose | Key inputs | Secrets |
-|----------|---------|------------|---------|
-| `build-app-no-db.yml` | Maven build + optional Docker image build/push, no DB | `java-version`, `build-image`, `push-image`, `namespace` | — |
-| `build-feature.yml` | Build feature branch (no deploy) | `java-version`, `t-2c`, `working-directory` | — |
-| `codeql.yml` | CodeQL static analysis (+ optional Sonar) | `sonar`, `java-version`, `t-2c` | `SONAR_TOKEN` (optional, brukes når `sonar: true`) |
-| `deploy.yml` | Deploy image to a NAIS cluster | `image` (req), `cluster` (req), `namespace`, `naiserator_file`, `gar` | — |
-| `deploy-storybook.yml` | Build + deploy Storybook to GitHub Pages | `package-manager` (req), `cache` (req) | — |
-| `mvn-dependency-submission.yml` | Submit Maven dep graph to GitHub Dependency Submission API | `java-version` | — |
-| `release-drafter.yml` | Auto-draft release notes | — | — |
-| `release-feature.yml` | Release artifact from a feature branch | `release-version` (req), `release-branch`, `release-profiles` | — |
+| Workflow                        | Purpose                                                    | Key inputs                                                            | Secrets                                            |
+| ------------------------------- | ---------------------------------------------------------- | --------------------------------------------------------------------- | -------------------------------------------------- |
+| `build-app-no-db.yml`           | Maven build + optional Docker image build/push, no DB      | `java-version`, `build-image`, `push-image`, `namespace`              | —                                                  |
+| `build-feature.yml`             | Build feature branch (no deploy)                           | `java-version`, `t-2c`, `working-directory`                           | —                                                  |
+| `codeql.yml`                    | CodeQL static analysis (+ optional Sonar)                  | `sonar`, `java-version`, `t-2c`                                       | `SONAR_TOKEN` (optional, brukes når `sonar: true`) |
+| `deploy.yml`                    | Deploy image to a NAIS cluster                             | `image` (req), `cluster` (req), `namespace`, `naiserator_file`, `gar` | —                                                  |
+| `deploy-storybook.yml`          | Build + deploy Storybook to GitHub Pages                   | `package-manager` (req), `cache` (req)                                | —                                                  |
+| `mvn-dependency-submission.yml` | Submit Maven dep graph to GitHub Dependency Submission API | `java-version`                                                        | —                                                  |
+| `release-drafter.yml`           | Auto-draft release notes                                   | —                                                                     | —                                                  |
+| `release-feature.yml`           | Release artifact from a feature branch                     | `release-version` (req), `release-branch`, `release-profiles`         | —                                                  |
 
 Alle workflowene bruker det innebygde `GITHUB_TOKEN` automatisk (via
 `permissions:`) — de trenger ikke eksplisitt tilsendte secrets utover det som
@@ -34,12 +34,12 @@ står i tabellen. Send kun de secretsene som faktisk er deklarert; unngå
 
 Reusable steps for use inside any workflow.
 
-| Action | Purpose | Key inputs | Secrets |
-|--------|---------|------------|---------|
-| `build-maven-application` | Maven install with cache + build-version output | `t-2c`, `profil` | — |
-| `build-push-docker-image` | Build + push a Docker image | `build-version` (req), `dockerfile` (req), `push-image`, `docker_context` | — |
-| `knip-it` | Frontend unused-export detection (Knip) | `package-manager` (req), `node-version` | — |
-| `setup-yarnrc` | Yarn registry config for `@navikt/*` packages | — | — |
+| Action                    | Purpose                                         | Key inputs                                                                | Secrets |
+| ------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------- | ------- |
+| `build-maven-application` | Maven install with cache + build-version output | `t-2c`, `profil`                                                          | —       |
+| `build-push-docker-image` | Build + push a Docker image                     | `build-version` (req), `dockerfile` (req), `push-image`, `docker_context` | —       |
+| `knip-it`                 | Frontend unused-export detection (Knip)         | `package-manager` (req), `node-version`                                   | —       |
+| `setup-yarnrc`            | Yarn registry config for `@navikt/*` packages   | —                                                                         | —       |
 
 Composite actions deklarerer ikke egne secrets — de arver `GITHUB_TOKEN` og
 miljøet fra jobben som kaller dem.
@@ -75,4 +75,3 @@ steps:
 
 External actions must be pinned to a full commit SHA with a ratchet comment —
 see the [pinning policy in fp-context](https://github.com/navikt/fp-context/blob/main/operations/ci-cd.md#workflow-pinning--ratchet-policy).
-

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Triggered via `workflow_call`.
 
 | Workflow | Purpose | Key inputs |
 |----------|---------|------------|
-| `build-app-no-db.yml` | Maven build + optional Docker image build/push, no DB | `java-version`, `build-image`, `push-image`, `use-reader` |
-| `build-feature.yml` | Build feature branch (no deploy) | `java-version`, `t-2c`, `use-reader`, `working-directory` |
+| `build-app-no-db.yml` | Maven build + optional Docker image build/push, no DB | `java-version`, `build-image`, `push-image`, `namespace` |
+| `build-feature.yml` | Build feature branch (no deploy) | `java-version`, `t-2c`, `working-directory` |
 | `codeql.yml` | CodeQL static analysis (+ optional Sonar) | `language`, `sonar`, `java-version` |
 | `deploy.yml` | Deploy image to a NAIS cluster | `image` (req), `cluster` (req), `namespace`, `naiserator_file`, `gar` |
 | `deploy-storybook.yml` | Build + deploy Storybook to GitHub Pages | `package-manager` (req), `cache` (req) |


### PR DESCRIPTION
## Sammendrag
- Fjerner `use-reader`-inputen fra `build-app-no-db.yml`, `build-feature.yml` og `codeql.yml`, og bruker alltid `${{ secrets.GITHUB_TOKEN }}` i stedet for `READER_TOKEN`-ternærene.
- Oppdaterer `README.md` slik at input-tabellen ikke lenger nevner `use-reader`.
- Herder alle checkout-steg med `persist-credentials: false` (workflows og composite actions) for å unngå at git-credential blir liggende igjen på runneren (zizmor `artipacked`: 0).
- Fjerner alle zizmor `template-injection`-funn — også i composite-actionene `build-maven-application` og `build-push-docker-image` — ved å flytte `${{ ... }}`-uttrykk ut i steg-nivå `env:`-variabler.
- Forenkler `codeql.yml` til java-only: fjerner `language`-inputen, autobuild-steget og den separate SONAR_TOKEN-sjekken.
- Rydder kommentarer/whitespace i `deploy-storybook.yml` og øvrige workflows.

## Breaking changes
- **`use-reader`-inputen er fjernet** fra tre reusable workflows. Ingen reell konsument setter `use-reader: true`, så dette er trygt.
- **`language`-inputen i `codeql.yml` er fjernet** (workflowen er nå java-only). Ingen reell konsument sender `language:`.

## Validering
- `zizmor --offline --persona=regular .github/` — `template-injection`: 0, `artipacked`: 0 (kun 6 by-design `unpinned-uses` på egne `@main`/`@master`-reusables gjenstår).
- `python3 -c "yaml.safe_load_all(...)"` på alle endrede workflow- og action-filer — OK.
- Bekreftet at ingen `READER_TOKEN`/`use-reader` gjenstår i workflow-filene.
